### PR TITLE
Remove outdated badge

### DIFF
--- a/notebooks/boston_light_swim/README.md
+++ b/notebooks/boston_light_swim/README.md
@@ -1,7 +1,5 @@
 # Boston light swim
 
-[![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/ocefpaf/boston_light_swim)
-
 Sea Surface Temperature forecast for the Boston Light Swim
 
 


### PR DESCRIPTION
@rsignell-usgs we should rely only on the badge at the main `README` in the root of the repo.