### PR TITLE
Remove the ioos channel and utilities pkg

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: IOOS
 channels:
     - conda-forge
-    - ioos
 dependencies:
     - python=3.5
     - anaconda-navigator
@@ -60,6 +59,5 @@ dependencies:
     - statsmodels
     - sympy
     - thredds_crawler
-    - utilities
     - xarray
     - xlrd


### PR DESCRIPTION
We no longer need this. Everything is either in `conda-forge` or internal.