### PR TITLE
Find HFRadar currents notebook

### DIFF
--- a/notebooks/hfradar/finding_HFRadar_currents.ipynb
+++ b/notebooks/hfradar/finding_HFRadar_currents.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "# Finding Near real-time current data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import time\n",
+    "import warnings\n",
+    "\n",
+    "ioos_tools = os.path.join(os.path.pardir, os.path.pardir)\n",
+    "sys.path.append(ioos_tools)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timedelta\n",
+    "\n",
+    "# Region: West coast.\n",
+    "bbox = [-123, 36, -121, 40]\n",
+    "crs = 'urn:ogc:def:crs:OGC:1.3:CRS84'\n",
+    "    \n",
+    "# Temporal range: Last week.\n",
+    "now = datetime.utcnow()\n",
+    "start,  stop = now - timedelta(days=(7)), now\n",
+    "\n",
+    "# Surface velocity CF names.\n",
+    "cf_names = ['surface_northward_sea_water_velocity',\n",
+    "            'surface_eastward_sea_water_velocity']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from owslib import fes\n",
+    "from ioos_tools.ioos import fes_date_filter\n",
+    "\n",
+    "kw = dict(wildCard='*', escapeChar='\\\\',\n",
+    "          singleChar='?', propertyname='apiso:AnyText')\n",
+    "\n",
+    "or_filt = fes.Or([fes.PropertyIsLike(literal=('*%s*' % val), **kw)\n",
+    "                  for val in cf_names])\n",
+    "\n",
+    "# Exclude GNOME returns.\n",
+    "not_filt = fes.Not([fes.PropertyIsLike(literal='*GNOME*', **kw)])\n",
+    "\n",
+    "begin, end = fes_date_filter(start, stop)\n",
+    "bbox_crs = fes.BBox(bbox, crs=crs)\n",
+    "filter_list = [fes.And([bbox_crs, begin, end, or_filt, not_filt])]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "http://www.ngdc.noaa.gov/geoportal/csw\n",
+      "\n",
+      "\n",
+      "https://dev-catalog.ioos.us/csw\n",
+      "hycom_global\n",
+      "ncep_global\n",
+      "\n",
+      "http://geoport.whoi.edu/csw\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from owslib.csw import CatalogueServiceWeb\n",
+    "\n",
+    "\n",
+    "catalogs = ['http://www.ngdc.noaa.gov/geoportal/csw',\n",
+    "            'https://dev-catalog.ioos.us/csw',\n",
+    "            'http://geoport.whoi.edu/csw']\n",
+    "\n",
+    "for endpoint in catalogs:\n",
+    "    csw = CatalogueServiceWeb(endpoint, timeout=60)\n",
+    "    csw.getrecords2(constraints=filter_list, maxrecords=1000, esn='full')\n",
+    "    records = '\\n'.join(csw.records.keys())\n",
+    "    print('{}\\n{}\\n'.format(endpoint, records))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### We could not find any HF-Radar data there :-(\n",
+    "\n",
+    "### Let's test removing the time constraint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "http://www.ngdc.noaa.gov/geoportal/csw\n",
+      "HFRNet/USWC/500m/hourly/RTV\n",
+      "HFRNet/USWC/1km/hourly/RTV\n",
+      "HFRNet/USWC/2km/hourly/RTV\n",
+      "HFRNet/USWC/6km/hourly/RTV\n",
+      "HFR/USWC/1km/hourly/RTV/HFRADAR,_US_West_Coast,_1km_Resolution,_Hourly_RTV_best.ncd\n",
+      "HFR/USWC/2km/hourly/RTV/HFRADAR,_US_West_Coast,_2km_Resolution,_Hourly_RTV_best.ncd\n",
+      "\n",
+      "https://dev-catalog.ioos.us/csw\n",
+      "hycom_global\n",
+      "ncep_global\n",
+      "CA_DAS\n",
+      "CORDC_MONTHLY\n",
+      "UCSC\n",
+      "\n",
+      "http://geoport.whoi.edu/csw\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "filter_list = [fes.And([bbox_crs, or_filt, not_filt])]\n",
+    "\n",
+    "\n",
+    "for endpoint in catalogs:\n",
+    "    csw = CatalogueServiceWeb(endpoint, timeout=60)\n",
+    "    csw.getrecords2(constraints=filter_list, maxrecords=1000, esn='full')\n",
+    "    records = '\\n'.join(csw.records.keys())\n",
+    "    print('{}\\n{}\\n'.format(endpoint, records))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [default]",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
@jbosch-noaa, @rsignell-usgs, and @lukecampbell this is an exercise to find and explore near real-time HF-Radar currents from 3 catalogs. You can see the partial results in:

http://nbviewer.jupyter.org/github/ocefpaf/notebooks_demos/blob/find_hfradar/notebooks/hfradar/finding_HFRadar_currents.ipynb

Note in cells [4]-[5] that the `ioos` and `whoi`catalog does not return any HF-radar data\* while the `ngdc` catalog returns something only when we remove the date constraint.

\* There is a monthly averaged HF-Radar in the `ioos` catalog though.