### PR TITLE
Fix env on Windows

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: IOOS
 channels:
     - ioos
+    - defaults
     - conda-forge
 dependencies:
     - python=3.4

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
     - python=3.4
     - anaconda-navigator
     - beautifulsoup4
+    - bokeh
     - cartopy
     - cc-plugin-glider
     - cmocean


### PR DESCRIPTION
We need this work around until `conda-forge` starts using `conda-build 2`.