### PR TITLE
Use short links

### DIFF
--- a/notebooks/2016-10-12-fetching_data.ipynb
+++ b/notebooks/2016-10-12-fetching_data.ipynb
@@ -143,7 +143,7 @@
     "\n",
     "In order to find out what we really get from that search we need to download the data. In the next two cells we will use a custom function to go from the collector object to a list of observations and a pandas `DataFrame` with all the data.\n",
     "\n",
-    "(Check the code for [`collector2table`](https://github.com/ioos/notebooks_demos/blob/17c6ba7f895f4663d87874ff39d5429be2d2d7d9/ioos_tools/ioos.py#L305-L359) for the implementation details.)"
+    "(Check the code for [`collector2table`](http://bit.ly/2eiUozm) for the implementation details.)"
    ]
   },
   {
@@ -166,7 +166,7 @@
    "execution_count": 6,
    "metadata": {
     "collapsed": false,
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [
     {
@@ -574,9 +574,11 @@
     "    sos_name=sos_name,\n",
     ")\n",
     "\n",
-    "data = collector2table(collector=collector,\n",
-    "                       config=config,\n",
-    "                       col='water_surface_height_above_reference_datum (m)')\n",
+    "data = collector2table(\n",
+    "    collector=collector,\n",
+    "    config=config,\n",
+    "    col='water_surface_height_above_reference_datum (m)'\n",
+    ")\n",
     "\n",
     "# Clean the table.\n",
     "table = dict(\n",
@@ -667,7 +669,7 @@
     "\n",
     "We can filter spikes with a simple first difference rule.\n",
     "\n",
-    "(Check the code for [`first_difference`](https://github.com/ioos/notebooks_demos/blob/17c6ba7f895f4663d87874ff39d5429be2d2d7d9/ioos_tools/qaqc.py#L127-L148) for the implementation details.)"
+    "(Check the code for [`first_difference`](http://bit.ly/2fAtuos) for the implementation details.)"
    ]
   },
   {


### PR DESCRIPTION
@jbosch-noaa notice in https://github.com/ioos/notebooks_demos/issues/100 that long links are corrupted during the notebooks conversion. That seems to be a problem in `nbconvert` and I will investigate this further. Meanwhile I am changing to short links to ensure they are not broken during the conversion.

Fixes #100 