### PR TITLE
Test Python 3.5 again

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
     - defaults
     - conda-forge
 dependencies:
-    - python=3.4
+    - python=3.5
     - anaconda-navigator
     - beautifulsoup4
     - bokeh


### PR DESCRIPTION
I resurrect the IOOS channel until conda-forge can catch up with `conda-build 2`. That should allow us to use `Python 3.5` on Windows. Fingers crossed.

See https://github.com/ioos/conda-recipes/issues/848