### PR TITLE
switching IOOS catalog csw back to development

### DIFF
--- a/notebooks/boston_light_swim/00-fetch_data.ipynb
+++ b/notebooks/boston_light_swim/00-fetch_data.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "catalogs:\n",
     "    - http://www.ngdc.noaa.gov/geoportal/csw\n",
-    "    - https://data.ioos.us/csw\n",
+    "    - https://dev-catalog.ioos.us/csw\n",
     "    - http://gamone.whoi.edu/csw\n",
     "\n",
     "# See https://raw.githubusercontent.com/OSGeo/Cat-Interop/master/LinkPropertyLookupTable.csv\n",


### PR DESCRIPTION
According to a November 9 email from @mwengren , the official IOOS catalog CSW endpoint at
https://data.ioos.us  will be launched Dec 14.   Switching back to the development endpoint until then.