### PR TITLE
Capitalize

### DIFF
--- a/webpage/_data/navigation.yml
+++ b/webpage/_data/navigation.yml
@@ -1,5 +1,7 @@
 # Main links links.
 main:
+  - title: The IOOS Data Demo Center
+    url: /
   - title: "Code Gallery"
     url: /code_gallery
   - title: "Video Tutorials"

--- a/webpage/index.md
+++ b/webpage/index.md
@@ -1,5 +1,5 @@
 ---
-title: IOOS data demo center
+title: The IOOS Data Demo Center
 layout: single
 ---
 

--- a/webpage/video_tutorials.md
+++ b/webpage/video_tutorials.md
@@ -16,7 +16,7 @@ NANOOS Visualization System (NVS)
 - [NANOOS Visualization System](https://www.youtube.com/watch?v=MEVz0jOsqmI)
 - [NANOOS Data Explorer](https://www.youtube.com/playlist?list=PLBvrtRArn5ffsBARjKsczvfxyYX1wGtFP)
 
-More video tutorials
+Python Demonstration Videos
 
 - [Catalog Driven Reproducible Workflows for Ocean-science](https://www.youtube.com/watch?v=05ax0lkQFrg)
 - [Extracting data from NOAA ERDDAP](https://www.youtube.com/watch?v=18xZoXu1USM)


### PR DESCRIPTION
Adresses https://github.com/ioos/notebooks_demos/pull/147#issuecomment-265242853

> 1.  Capitalize title of the blog on the landing page: "The IOOS Data Demo Center"

Done.

> 3. Under the Video Tutorials, we should rename the third group "Python Demonstration Videos" 

Done.

> 2.  I feel like we should have the title of this blog static somewhere on all the sub pages also.  May be at the top of the sidebar? Maybe in the blue bar?  Just so folks don't forget what this page is called. This idea is up for debate.

The side bar and the blue top bar are rendered by the theme and we can only add extra entries (topics on the former and sections on the latter). The image show how that title looks like an extra topic in the side bar (the all caps is part of the theme.)

![sidebar](https://cloud.githubusercontent.com/assets/950575/20940680/702583de-bbd2-11e6-908a-b6573293d8dd.png)

and this is how it looks tile when place at the top banner (it behaves also as a link to the main page the same way the logo is):

![title](https://cloud.githubusercontent.com/assets/950575/20940827/e45187bc-bbd2-11e6-9712-c32d3fbd64ae.png)


Which one do you prefer @jbosch-noaa?