### PR TITLE
Python 2 and 3 envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,27 @@ matrix:
   fast_finish: true
   include:
     - os: linux
-      env: TEST_TARGET=default
+      env: TEST_TARGET=default ENV_NAME="IOOS3" ENV="environment.yml"
     - os: linux
-      env: TEST_TARGET=notebooks
+      env: TEST_TARGET=notebooks ENV_NAME="IOOS3" ENV="environment.yml"
     - os: linux
-      env: TEST_TARGET=staged_notebooks
+      env: TEST_TARGET=notebooks_python2 ENV_NAME="IOOS2" ENV="environment-python-2.yml"
     - os: linux
-      env: TEST_TARGET=publish
+      env: TEST_TARGET=staged_notebooks ENV_NAME="IOOS3" ENV="environment.yml"
+    - os: linux
+      env: TEST_TARGET=publish ENV_NAME="IOOS3" ENV="environment.yml"
     - os: osx
-      env: TEST_TARGET=notebooks
+      env: TEST_TARGET=notebooks ENV_NAME="IOOS3" ENV="environment.yml"
   allow_failures:
     - os: linux
-      env: TEST_TARGET=staged_notebooks
+      env: TEST_TARGET=staged_notebooks ENV_NAME="IOOS3" ENV="environment.yml"
 
 before_install:
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then
       openssl aes-256-cbc -K $encrypted_2ed57bb9ae7e_key -iv $encrypted_2ed57bb9ae7e_iv -in deploy_key.enc -out deploy_key -d ;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then URL="https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh" ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" ; fi
   # GUI (R png figures).
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0 ; sh -e /etc/init.d/xvfb start ; fi
   - wget $URL -O miniconda.sh
@@ -32,12 +34,15 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a
+  - conda update --quiet conda
 
 install:
-  - conda env create --file environment.yml
-  - source activate IOOS
+  - conda env create --quiet --file "$ENV"
+  - source activate "$ENV_NAME"
+
+  # Debug.
+  - conda info -a
+  - conda list
 
 script:
   # Default test is mostly codding standards.
@@ -52,6 +57,9 @@ script:
     fi
   # The notebook test runs the blog notebooks.
   - if [[ $TEST_TARGET == 'notebooks' ]]; then
+      cd tests && python test_notebooks.py ;
+    fi
+  - if [[ $TEST_TARGET == 'notebooks_python2' ]]; then
       cd tests && python test_notebooks.py ;
     fi
   # Staged notebooks are the notebooks that are not in the blog yet.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ build: false
 environment:
   matrix:
     - PYTHON: "C:\\Miniconda-x64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Miniconda"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "32"
+      ENV_NAME: "IOOS3"
+      ENV: "environment.yml"
+    - PYTHON: "C:\\Miniconda-x64"
+      ENV_NAME: "IOOS2"
+      ENV: "environment-python-2.yml"
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
@@ -25,15 +25,19 @@ install:
 
   # Use the pre-installed Miniconda for the desired arch.
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - conda update --all --yes
-  - "conda-env create -f environment.yml"
-  - activate IOOS
-  - conda install console_shortcut --yes
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update --quiet conda
+  - conda env create --quiet --file "%ENV%"
+  - activate "%ENV_NAME%"
+  - conda install console_shortcut
   # Fortran cells.
-  - conda install -c conda-forge mingwpy --yes
+  - conda install --channel conda-forge mingwpy
   - set CFG=%CONDA_PREFIX%\Lib\distutils\distutils.cfg
   - echo [build] >> "%CFG%"
   - echo compiler=mingw32 >> "%CFG%"
+  # DEBUG.
+  - conda info
+  - conda list
 
 test_script:
     - cmd: cd tests && python test_notebooks.py

--- a/environment-python-2.yml
+++ b/environment-python-2.yml
@@ -1,11 +1,12 @@
-name: IOOS3
+name: IOOS2
 channels:
-  - conda-forge
+  - ioos
   - defaults
+  - conda-forge
 dependencies:
   - icu=56
   - libnetcdf=4.4.0
-  - python=3.5
+  - python=2.7
   - anaconda-navigator
   - bagit
   - beautifulsoup4

--- a/webpage/other_resources.md
+++ b/webpage/other_resources.md
@@ -33,7 +33,7 @@ then some of the paths below may need editing to reflect the user space folder!
 
 **ASIDE 1:** If you are using ArcGIS,
 or any other Python distribution,
-you should you should **uncheck** the boxes in the install script so that Anaconda is **not** made your default Python,
+you should **uncheck** the boxes in the install script so that Anaconda is **not** made your default Python,
 nor added to your path.
 You then need to activate `conda` by opening a command prompt terminal and typing:
 
@@ -82,7 +82,7 @@ type the following commands in the terminal or Windows command prompt:
 ```bash
 conda config --add channels conda-forge --force
 conda update --yes --all
-conda env create environment.yml
+conda env create --quiet --file environment.yml
 ```
 
 The first two, adding an extra channel and updating, are optional but recommended.
@@ -92,13 +92,19 @@ Once it's done building the environment,
 you can activate the environment by typing:
 
 ```bash
-activate IOOS  # Windows
-source activate IOOS  # OSX and Linux
+activate IOOS3  # Windows
+source activate IOOS3  # OSX and Linux
 ```
 
-**ASIDE 2:** This file is just a list of Python packages that will be installed in a new `conda` virtual environment named `IOOS`.
+**ASIDE 2:** This file is just a list of Python packages that will be installed in a new `conda` virtual environment named `IOOS3`.
 You can edit the file to add/remove software,
 and/or rename the environment name if you need more environments for different tasks.
+
+**ASIDE 3:** The default `Python` chosen for the environment is `3.5`.
+If you need Python 2.7 download [environment-python-2.yml](https://raw.githubusercontent.com/ioos/notebooks_demos/master/environment-python-2.yml) instead,
+and replace `environment.yml` for `environment-python-2.yml` in the instructions above to create an `IOOS2` environment.
+Note that you will need to substitute `IOOS3` for `IOOS2`.
+BTW, one can create both envs and use the Jupyter notebook kernel menu to switch between them.
 
 ## Exiting the IOOS environment
 
@@ -117,8 +123,8 @@ you must remember to activate the IOOS environment every time,
 by typing in a command prompt
 
 ```
-C:\Miniconda3\Scripts\activate IOOS  # Windows
-export PATH=$HOME/miniconda3/bin:$PATH && source activate IOOS  # OSX and Linux
+C:\Miniconda3\Scripts\activate IOOS3  # Windows
+export PATH=$HOME/miniconda3/bin:$PATH && source activate IOOS3  # OSX and Linux
 ```
 
 On all systems, to start the Jupyter notebook, just type:


### PR DESCRIPTION
No ready for merging yet!!! Still need to update the CIs and the docs. Adding this just to start a discussion.

@rsignell-usgs suggested that we should rename the `IOOS` env to `IOOS2` (Python 2) and IOOS3 (Python 3). Ideally we would still use IOOS3 as the default everywhere, but people would have the option to use a similar env by downloading the `environment-python-2.yml` file and creating an with with that one.