### PR TITLE
Add virtual space between entries

### DIFF
--- a/webpage/_data/navigation.yml
+++ b/webpage/_data/navigation.yml
@@ -13,9 +13,13 @@ site_nav:
     children:
       - title: "Installing the IOOS conda environment"
         url: /other_resources
+      - title: " "
       - title: "Opening netCDF files - hints from AODN"
         url: https://help.aodn.org.au/aodn-data-tools/user-code-library/
+      - title: " "
       - title: "Unidata Jupyter notebook gallery"
         url: http://unidata.github.io/notebook-gallery/
+      - title: " "
       - title: "Extracting and enriching OBIS data with R"
         url: http://iobis.org/tutorial/
+      - title: " "

--- a/webpage/_data/navigation.yml
+++ b/webpage/_data/navigation.yml
@@ -11,15 +11,11 @@ main:
 site_nav:
   - title: Other resources
     children:
-      - title: "Installing the IOOS conda environment"
+      - title: "1. Installing the IOOS conda environment"
         url: /other_resources
-      - title: " "
-      - title: "Opening netCDF files - hints from AODN"
+      - title: "2. Opening netCDF files - hints from AODN"
         url: https://help.aodn.org.au/aodn-data-tools/user-code-library/
-      - title: " "
-      - title: "Unidata Jupyter notebook gallery"
+      - title: "3. Unidata Jupyter notebook gallery"
         url: http://unidata.github.io/notebook-gallery/
-      - title: " "
-      - title: "Extracting and enriching OBIS data with R"
+      - title: "4. Extracting and enriching OBIS data with R"
         url: http://iobis.org/tutorial/
-      - title: " "


### PR DESCRIPTION
@jbosch-noaa this is the change you requested. If someone clicks between the links, in the empty title, they will be directed to a 404 page. That is the side effect of this hack.