### PR TITLE
Fix title

### DIFF
--- a/notebooks/2016-12-22-boston_light_swim.ipynb
+++ b/notebooks/2016-12-22-boston_light_swim.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# [The Boston Light Swim](http://bostonlightswim.org/)\n",
+    "# The Boston Light Swim\n",
     "\n",
     "In the past we demonstrated how to perform a CSW catalog search with [`OWSLib`](https://ioos.github.io/notebooks_demos//notebooks/2016-12-19-exploring_csw),\n",
     "and how to obtain near real-time data with [`pyoos`](https://ioos.github.io/notebooks_demos//notebooks/2016-10-12-fetching_data).\n",
     "In this notebook we will use both to find all observations and model data around the Boston Harbor to access the sea water temperature.\n",
     "\n",
     "\n",
-    "This workflow is part of an example to advise swimmers of the annual Boston lighthouse swim of the Boston Harbor water temperature conditions prior to the race. For more information regarding the workflow presented here see [Signell, Richard P.; Fernandes, Filipe; Wilcox, Kyle.   2016. \"Dynamic Reusable Workflows for Ocean Science.\" *J. Mar. Sci. Eng.* 4, no. 4: 68](http://dx.doi.org/10.3390/jmse4040068)."
+    "This workflow is part of an example to advise swimmers of the annual [Boston lighthouse swim](http://bostonlightswim.org/) of the Boston Harbor water temperature conditions prior to the race. For more information regarding the workflow presented here see [Signell, Richard P.; Fernandes, Filipe; Wilcox, Kyle.   2016. \"Dynamic Reusable Workflows for Ocean Science.\" *J. Mar. Sci. Eng.* 4, no. 4: 68](http://dx.doi.org/10.3390/jmse4040068)."
    ]
   },
   {

--- a/notebooks/2016-12-22-boston_light_swim.ipynb
+++ b/notebooks/2016-12-22-boston_light_swim.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# The Boston Light Swim\n",
+    "# The Boston Light Swim temperature analysis with Python\n",
     "\n",
     "In the past we demonstrated how to perform a CSW catalog search with [`OWSLib`](https://ioos.github.io/notebooks_demos//notebooks/2016-12-19-exploring_csw),\n",
     "and how to obtain near real-time data with [`pyoos`](https://ioos.github.io/notebooks_demos//notebooks/2016-10-12-fetching_data).\n",


### PR DESCRIPTION
Moves the markdown link from the title into the text to avoid it leaking into the gallery thumbnail.