### PR TITLE
add contact us link

### DIFF
--- a/webpage/_data/navigation.yml
+++ b/webpage/_data/navigation.yml
@@ -6,6 +6,8 @@ main:
     url: /code_gallery
   - title: "Video Tutorials"
     url: /video_tutorials
+  - title: "Contact Us"
+    url: /contact
 
 # Site navigation links.
 site_nav:

--- a/webpage/contact.md
+++ b/webpage/contact.md
@@ -1,0 +1,9 @@
+---
+title: IOOS Tutorials
+layout: single
+---
+
+<br>
+
+Feedback and questions are welcome.
+Please contact us at <a href="mailto:data.ioos@noaa.gov" target="_top">data.ioos@noaa.gov</a>

--- a/webpage/index.md
+++ b/webpage/index.md
@@ -13,4 +13,5 @@ The notebooks will come from a variety of authors including IOOS Program Office 
 Regional Association data managers, and other IOOS partners.
 If you think you have a nice example you would like to share please let us know!
 
-Feedback and questions are welcome.  Please contact us at data.ioos@noaa.gov
+Feedback and questions are welcome.
+Please contact us at <a href="mailto:data.ioos@noaa.gov" target="_top">data.ioos@noaa.gov</a>


### PR DESCRIPTION
@jbosch-noaa I cannot (at least I could not find how) add a direct link in the menu so I created a simple "contact.md" page that has the contact info when someone clicks on it.

I also updated the contact info to open the default e-mail client when clicked.