### PR TITLE
remove anaconda-navigator from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - icu=56
   - libnetcdf=4.4.0
   - python=3.5
-  - anaconda-navigator
   - bagit
   - beautifulsoup4
   - bokeh


### PR DESCRIPTION
We don't need anaconda-navigator in the environment. 
 It should instead by installed only in the miniconda base environment