### PR TITLE
remove binder and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # IOOS demonstrations and examples notebooks
 
-[![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/ioos/notebooks_demos) [![Build Status](https://travis-ci.org/ioos/notebooks_demos.svg?branch=master)](https://travis-ci.org/ioos/notebooks_demos) [![Build status](https://ci.appveyor.com/api/projects/status/0k2b8eurfg435xws/branch/master?svg=true)](https://ci.appveyor.com/project/ocefpaf/notebooks-demos/branch/master)
+| Platform       | Status                                                                                                                                                                        |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Linux and OS X | [![Build Status](https://travis-ci.org/ioos/notebooks_demos.svg?branch=master)](https://travis-ci.org/ioos/notebooks_demos)                                                   |
+| Windows        | [![Build status](https://ci.appveyor.com/api/projects/status/0k2b8eurfg435xws/branch/master?svg=true)](https://ci.appveyor.com/project/ocefpaf/notebooks-demos/branch/master) |
 
 
-See the rendered version at https://ioos.github.io/notebooks_demos/
+See the rendered version at https://ioos.github.io/notebooks_demos
+
+To suggest a notebook or ask questions please open an issue at: https://github.com/ioos/notebooks_demos/issues
+
+## Citation
+
+[![DOI](https://zenodo.org/badge/58492405.svg)](https://zenodo.org/badge/latestdoi/58492405)
+
+## License
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,3 @@ To suggest a notebook or ask questions please open an issue at: https://github.c
 ## Citation
 
 [![DOI](https://zenodo.org/badge/58492405.svg)](https://zenodo.org/badge/latestdoi/58492405)
-
-## License
-
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
@jbosch-noaa I removed the `binder` badge b/c, unfortunately, binder became an unreliable service. (I am looking into alternatives.)

I also added more metadta, most importantly a license. Can you please check if the CC by is an OK license for `IOOS`?

You can see a rendered version at: https://github.com/ocefpaf/notebooks_demos/blob/readme/README.md