### PR TITLE
Suggest a notebook template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,5 @@
-To suggest a notebook for the code gallery please open an issue answering the questions below:
+If you are opening an issue regarding an existing notebook/code or the webpage just ignore the instructions below.
+If you want to suggest a notebook for the code gallery please open answer these questions:
 
 - [ ] What is language(s) for used in the example?
 - [ ] Is it focused on a particular module/service?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+To suggest a notebook for the code gallery please open an issue answering the questions below:
+
+- [ ] What is language(s) for used in the example?
+- [ ] Is it focused on a particular module/service?
+- [ ] Can you provide a minimum example of the expected code and results in a notebook?
+
+Please provide a detailed description of the suggested example below:

--- a/webpage/_config.yml
+++ b/webpage/_config.yml
@@ -121,6 +121,12 @@ author:
   xing             :
   youtube          :
 
+forkme:
+  active: true
+  title: Suggest a Demo!
+  url: https://github.com/ioos/notebooks_demos/issues/new
+  position: top-right
+
 # Reading Files
 include:
   - .htaccess


### PR DESCRIPTION
@jbosch-noaa this does not add the ribbon from #175 yet because we need to modify the theme. See https://github.com/ioos/ioos_jekyll_theme/pull/26

Right now it only adds text boilerplate, that users will see when opening an issue via the link, and the ribbon configuration. (I guess we need to warn users regarding "regular" issues.)

Here is how it looks:

![ribbon](https://cloud.githubusercontent.com/assets/950575/23808549/083cbe6a-05a9-11e7-8e34-409c237fca65.png)
