### PR TITLE
Remove libnetcdf pin

### DIFF
--- a/environment-python-2.yml
+++ b/environment-python-2.yml
@@ -4,7 +4,6 @@ channels:
   - defaults
 dependencies:
   - python=2.7
-  - libnetcdf=4.4.0
   - bagit
   - beautifulsoup4
   - bokeh
@@ -34,7 +33,7 @@ dependencies:
   - mplleaflet
   - nb_conda_kernels
   - nbdime
-  - netcdf4=1.2.4
+  - netcdf4
   - numpy
   - oceans
   - oct2py

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
   - defaults
 dependencies:
   - python=3.6
-  - libnetcdf=4.4.0
   - bagit
   - beautifulsoup4
   - bokeh
@@ -34,7 +33,7 @@ dependencies:
   - mplleaflet
   - nb_conda_kernels
   - nbdime
-  - netcdf4=1.2.4
+  - netcdf4
   - numpy
   - oceans
   - oct2py


### PR DESCRIPTION
@rsignell-usgs I patched the latest version of `libnetcdf` in https://github.com/conda-forge/libnetcdf-feedstock/pull/19/commits/fafecd65f06ae8fc8e8d617c1c2584e986255c89 and this will allow us to drop the downgrading here.