### PR TITLE
Video IFrames

### DIFF
--- a/webpage/video_tutorials.md
+++ b/webpage/video_tutorials.md
@@ -8,15 +8,33 @@ layout: single
 ![IOOS-logo_little]({{ site.url }}/{{ site.baseurl }}/assets/IOOS-logo_little.png) IOOS
 
 - [COMT Tutorial](https://www.youtube.com/watch?v=Dqc1C1HeemQ)
+
+<iframe id="video" width="420" height="315" src="//www.youtube.com/embed/Dqc1C1HeemQ?rel=0" frameborder="0" allowfullscreen></iframe>
+
 - [IOOS EDS Demo](https://nccospublicstor.blob.core.windows.net/ioos/ioos_demo_1280.mp4)
+
+<iframe id="video" width="420" height="315" src="https://nccospublicstor.blob.core.windows.net/ioos/ioos_demo_1280.mp4" frameborder="0" allowfullscreen></iframe>
+
 - [MBON Portal Tutorial](https://www.youtube.com/watch?v=ZITqDRa6u9c)
+
+<iframe id="video" width="420" height="315" src="//www.youtube.com/embed/ZITqDRa6u9c?rel=0" frameborder="0" allowfullscreen></iframe>
 
 ![NANOOS logo]({{ site.url }}/{{ site.baseurl }}/assets/NANOOS.png) NANOOS Visualization System (NVS)
 
 - [NANOOS Visualization System](https://www.youtube.com/watch?v=MEVz0jOsqmI)
+
+<iframe id="video" width="420" height="315" src="//www.youtube.com/embed/MEVz0jOsqmI?rel=0" frameborder="0" allowfullscreen></iframe>
+
 - [NANOOS Data Explorer](https://www.youtube.com/playlist?list=PLBvrtRArn5ffsBARjKsczvfxyYX1wGtFP)
+
+<iframe id="video" width="420" height="315" src="//www.youtube.com/embed/PLBvrtRArn5ffsBARjKsczvfxyYX1wGtFP?rel=0" frameborder="0" allowfullscreen></iframe>
 
 ![Python logo]({{ site.url }}/{{ site.baseurl }}/assets/python.png) Python Demonstration Videos
 
 - [Catalog Driven Reproducible Workflows for Ocean-science](https://www.youtube.com/watch?v=05ax0lkQFrg)
+
+<iframe id="video" width="420" height="315" src="//www.youtube.com/embed/05ax0lkQFrg?rel=0" frameborder="0" allowfullscreen></iframe>
+
 - [Extracting data from NOAA ERDDAP](https://www.youtube.com/watch?v=18xZoXu1USM)
+
+<iframe id="video" width="420" height="315" src="//www.youtube.com/embed/18xZoXu1USM?rel=0" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
@jbosch-noaa this is how the page will look like with the video IFrame.

![site](https://cloud.githubusercontent.com/assets/950575/24727219/a18e7360-1a2b-11e7-90d4-f5398bbecd3c.png)


I am on the fence b/c I like the simple listing we have now but I understand that some people would prefer to watch the videos directly instead of being re-directed to youtube. What do you think? Close it or merge it?