### PR TITLE
Reduce the CI run time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,74 +2,105 @@ language: generic
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/miniconda
+
+# Removing the directory will remove the env but leave the cached packages
+# at $HOME/miniconda/pkgs. That is a win-win because when re-creating the
+# env we will download only the new packages.
+before_cache:
+  - rm -rf $HOME/miniconda/envs/IOOS
+
+# All but one of the tests are executed with the Python 3 env.
+env:
+  global:
+    - ENV: environment.yml
+
 matrix:
   fast_finish: true
   include:
     - os: linux
-      env: TEST_TARGET=coding_standards ENV_NAME="IOOS3" ENV="environment.yml"
+      env: TEST_TARGET=notebooks_python2 ENV="environment-python-2.yml"
     - os: linux
-      env: TEST_TARGET=notebooks_python3 ENV_NAME="IOOS3" ENV="environment.yml"
+      env: TEST_TARGET=notebooks_python3
     - os: linux
-      env: TEST_TARGET=notebooks_python2 ENV_NAME="IOOS2" ENV="environment-python-2.yml"
+      env: TEST_TARGET=coding_standards
     - os: linux
-      env: TEST_TARGET=staged_notebooks ENV_NAME="IOOS3" ENV="environment.yml"
+      env: TEST_TARGET=staged_notebooks
     - os: linux
-      env: TEST_TARGET=publish ENV_NAME="IOOS3" ENV="environment.yml"
+      env: TEST_TARGET=publish
     - os: osx
-      env: TEST_TARGET=notebooks_python3 ENV_NAME="IOOS3" ENV="environment.yml"
+      env: TEST_TARGET=notebooks_python3
   allow_failures:
     - os: linux
-      env: TEST_TARGET=staged_notebooks ENV_NAME="IOOS3" ENV="environment.yml"
+      env: TEST_TARGET=staged_notebooks
     - os: osx
-      env: TEST_TARGET=notebooks_python3 ENV_NAME="IOOS3" ENV="environment.yml"
+      env: TEST_TARGET=notebooks_python3
 
 before_install:
-  - if [ $TRAVIS_PULL_REQUEST == 'false' ]; then
-      openssl aes-256-cbc -K $encrypted_2ed57bb9ae7e_key -iv $encrypted_2ed57bb9ae7e_iv -in deploy_key.enc -out deploy_key -d ;
+  - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+    elif [ "$TRAVIS_OS_NAME" == "linux" ] ; then
+      URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
     fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" ; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" ; fi
+    echo ""
+    if [ ! -f $HOME/miniconda/bin/conda ] ; then
+      echo "Fresh miniconda installation."
+      wget $URL -O miniconda.sh
+      rm -rf $HOME/miniconda
+      bash miniconda.sh -b -p $HOME/miniconda
+    fi
+    export PATH="$HOME/miniconda/bin:$PATH"
+    conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
+    conda update conda
+
   # GUI (R png figures).
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export DISPLAY=:99.0 ; sh -e /etc/init.d/xvfb start ; fi
-  - wget $URL -O miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update --quiet conda
+
+  ## Pages deploy_key.
+  #- if [ $TRAVIS_PULL_REQUEST == "false" ]; then
+      #openssl aes-256-cbc -K $encrypted_2ed57bb9ae7e_key -iv $encrypted_2ed57bb9ae7e_iv -in deploy_key.enc -out deploy_key -d ;
+    #fi
 
 install:
-  - conda env create --quiet --file "$ENV"
-  - source activate "$ENV_NAME"
+  - conda env create --file "$ENV" --name IOOS
+  - source activate IOOS
 
   # Debug.
-  - conda info -a
+  - conda info --all
   - conda list
 
 script:
-  # Default test is mostly codding standards.
+  # Default test is mostly coding standards.
   # The notebook PEP 8 test ignore:
   # W391: blank line at end of file (always present when using nbconvert)
   # E226: missing whitespace around arithmetic operator (not enforced by PEP 8)
   # E402: module level import not at top of file (in notebooks it is clearer to import in the first cell the module is used.)
-  # In addition the magic cells are skipped with `grep -v '^get_ipython'` b/c they are not compliant when converted to script.
-  - if [ $TEST_TARGET == 'coding_standards' ]; then
+  # In addition the magic cells are skipped with `grep -v "^get_ipython"` b/c they are not compliant when converted to script.
+  - if [ $TEST_TARGET == "coding_standards" ]; then
       find . -type f -name "*.py" ! -name "conf.py" | xargs flake8 --max-line-length=100 ;
-      for file in $(find . -type f -name "*.ipynb" ! -name "2017-01-23-R-notebook.ipynb" ); do jupyter nbconvert --template=tests/strip_markdown.tpl --stdout --to python $file | grep -v '^get_ipython' | flake8 - --ignore=W391,E226,E402 --max-line-length=100 --show-source ; done ;
+      for file in $(find . -type f -name "*.ipynb" ! -name "2017-01-23-R-notebook.ipynb" ); do jupyter nbconvert --template=tests/strip_markdown.tpl --stdout --to python $file | grep -v "^get_ipython" | flake8 - --ignore=W391,E226,E402 --max-line-length=100 --show-source ; done ;
     fi
-  # Test the blog notebook.
-  - if [ $TEST_TARGET == 'notebooks_python3' ]; then
+
+  # Test notebooks on Python 3.
+  - if [ $TEST_TARGET == "notebooks_python3" ]; then
       cd tests && python test_notebooks.py ;
     fi
-  - if [ $TEST_TARGET == 'notebooks_python2' ]; then
+
+  # Test notebooks on Python 2.
+  - if [ $TEST_TARGET == "notebooks_python2" ]; then
       cd tests && python test_notebooks.py ;
     fi
-  # Test the staged notebooks.
-  - if [ $TEST_TARGET == 'staged_notebooks' ]; then
+
+  # Test staged notebooks.
+  - if [ $TEST_TARGET == "staged_notebooks" ]; then
       cd tests && python test_staged_notebooks.py ;
     fi
+
   # Publish the notebooks.
-  - if [ $TEST_TARGET == 'publish' ]; then
+  - if [ $TEST_TARGET == "publish" ]; then
       cd webpage && python make_index.py && cd ..;
       find notebooks/ -maxdepth 1 -name \*.ipynb -print0 | xargs -0 -n1 jupyter nbconvert --to=markdown --template="jupyter-jekyll.tpl" --output-dir=webpage/_notebooks ;
       bash webpage/deploy.sh ;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,6 @@ build: false
 environment:
   matrix:
     - PYTHON: "C:\\Miniconda36-x64"
-      ENV_NAME: "IOOS3"
-      ENV: "environment.yml"
-
-    - PYTHON: "C:\\Miniconda-x64"
-      ENV_NAME: "IOOS2"
-      ENV: "environment-python-2.yml"
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
@@ -26,13 +20,13 @@ install:
 
   # Use the pre-installed Miniconda for the desired arch.
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update --quiet conda
-  - conda env create --quiet --file "%ENV%"
-  - activate "%ENV_NAME%"
-  - conda install console_shortcut
-  # DEBUG.
-  - conda info
+  - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
+  - conda update conda
+  - conda env create --file environment.yml --name IOOS
+  - activate IOOS
+
+  # Debug.
+  - conda info --all
   - conda list
 
 test_script:


### PR DESCRIPTION
The CIs are taking too long and as we accumulate more notebooks it will only get longer.
This PR tries to alleviate that by reducing the AppVeyor build matrix and caching the environment on Travis-CI.

Another idea is to move old notebooks to a `allow_failure` section with `fast_finish`. That way we would cover only the new submitted notebook in every new PR.