### PR TITLE
Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ See the rendered version at https://ioos.github.io/notebooks_demos
 
 To suggest a notebook or ask questions please open an issue at: https://github.com/ioos/notebooks_demos/issues
 
+## Binder
+
+[![Binder](http://mybinder.org/badge.svg)](https://beta.mybinder.org/v2/gh/ioos/notebooks_demos/master)
+
 ## Citation
 
 [![DOI](https://zenodo.org/badge/58492405.svg)](https://zenodo.org/badge/latestdoi/58492405)

--- a/jupyter-jekyll.tpl
+++ b/jupyter-jekyll.tpl
@@ -88,5 +88,5 @@ unknown type  {{ cell.type }}
 <br>
 Right click and choose Save link as... to
 [download](https://raw.githubusercontent.com/ioos/notebooks_demos/master/notebooks/{{resources['metadata']['name']}}.ipynb)
-this notebook, or see a static view [here](http://nbviewer.ipython.org/urls/raw.githubusercontent.com/ioos/notebooks_demos/master/notebooks/{{resources['metadata']['name']}}.ipynb).
+this notebook, or click [here](https://beta.mybinder.org/v2/gh/ioos/notebooks_demos/master?filepath=notebooks/{{resources['metadata']['name']}}.ipynb) to run a live instance of this notebook.
 {%- endblock footer -%}


### PR DESCRIPTION
@jbosch-noaa and @rsignell-usgs thanks to the awesome work of @choldgraf, @yuvipanda, and many others, we can restore the binder badge with an extra feature! Now we have a link to a live notebook in the footer of every page. Users should be able to just lick there and run.

I replaced the static `nbviewer` link with the live binder one to avoid polluting the footer.

PS: this version of binder is still beta, but quite stable and more reliable than the old binder at this moment. 