### PR TITLE
Add sensorml2iso module

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -60,6 +60,7 @@ dependencies:
   - seaborn
   - seawater
   - selenium
+  - sensorml2iso
   - shapely
   - siphon
   - spyder


### PR DESCRIPTION
Can we add this module into the default IOOS environment?