### PR TITLE
Fix Windows installation of the default env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
   - travis_wait conda env create --file environment.yml --name IOOS
   - source activate IOOS
   # Only until we package it for Windows, then we can drop this line.
-  - conda install r-obistools --yes
+  - conda install --channel conda-forge r-obistools --yes
 
   # Debug.
   - conda info --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ before_install:
 install:
   - travis_wait conda env create --file environment.yml --name IOOS
   - source activate IOOS
+  # Only until we package it for Windows, then we can drop this line.
+  - conda install r-obistools --yes
 
   # Debug.
   - conda info --all

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,16 +18,12 @@ install:
      Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
        throw "There are newer queued builds for this pull request, failing early." }
 
-  # Use the pre-installed Miniconda for the desired arch.
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
   - conda update conda
   - conda env create --file environment.yml --name IOOS
   - activate IOOS
 
-  # Debug.
+test_script:
   - conda info --all
   - conda list
-
-test_script:
-  - cd tests && python test_notebooks.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,4 @@ install:
   - conda list
 
 test_script:
-  - cmd: cd tests
-  - cmd: python test_notebooks.py
+  - cd tests && python test_notebooks.py

--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,7 @@ dependencies:
   - iris>=1.12
   - jupyter
   - jupyter_contrib_nbextensions
+  - jupyterthemes
   - matplotlib
   - nb_conda_kernels
   - nbdime

--- a/environment.yml
+++ b/environment.yml
@@ -88,7 +88,6 @@ dependencies:
   - r-lubridate
   - r-mapdata
   - r-ncdf4
-  - r-obistools
   - r-oce
   - r-rcolorbrewer
   - r-rerddap

--- a/environment.yml
+++ b/environment.yml
@@ -59,6 +59,7 @@ dependencies:
   - rasterio
   - requests
   - retrying
+  - rise
   - rpy2
   - rtree
   - scikit-learn


### PR DESCRIPTION
This should help users that are using the IOOS env as their default Python distribution to install it on Windows without any workarounds.
(The workaround is in Travis-CI now.)