### PR TITLE
fix latest folium syntax

### DIFF
--- a/notebooks/2018-03-30-wave_height_assessment.ipynb
+++ b/notebooks/2018-03-30-wave_height_assessment.ipynb
@@ -906,7 +906,7 @@
     "        w.add_to(m)\n",
     "\n",
     "    if line:\n",
-    "        p = folium.PolyLine(get_coordinates(bbox), color='#FF0000', weight=2, opacity=0.9, latlon=True)\n",
+    "        p = folium.PolyLine(get_coordinates(bbox), color='#FF0000', weight=2, opacity=0.9)\n",
     "        p.add_to(m)\n",
     "    return m"
    ]
@@ -1151,7 +1151,7 @@
    "id": "fbf3b8c50a0e0a4a61438470cdb11523"
   },
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1165,7 +1165,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Folium no longer takes the `latlon=True` argument.
(Note that I'm not re-running the notebook to avoid change its current state during the shutdown b/c the servers we are fetching the data are probably down.)