### PR TITLE
use non-R env as default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
   - conda update conda
   - conda env create --file environment.yml --name IOOS
-  - activate IOOS
+  - conda activate IOOS
 
 test_script:
   - conda info --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ before_install:
     fi
     export PATH="$HOME/miniconda/bin:$PATH"
     conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
-    conda update conda
+    conda update conda --quiet
     conda config --remove channels defaults
-    conda config --add channels conda-forge
+    conda config --add channels conda-forge --force
 
   # GUI (R png figures).
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export DISPLAY=:99.0 ; sh -e /etc/init.d/xvfb start ; fi
@@ -64,8 +64,6 @@ before_install:
 install:
   - travis_wait conda env create --file environment.yml --name IOOS
   - source activate IOOS
-  # Only until we package it for Windows, then we can drop this line.
-  - conda install --channel conda-forge r-obistools --yes
 
   # Debug.
   - conda info --all

--- a/environment-python_and_r.yml
+++ b/environment-python_and_r.yml
@@ -3,77 +3,71 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.6
-  - arrow
-  - autopep8
+  - python=3.7
   - bagit
-  - beautifulsoup4
   - bokeh
   - cartopy
   - cc-plugin-glider
   - cc-plugin-ncei
   - compliance-checker
-  - ctd
   - cython
   - erddapy
-  - fiona
   - flake8
-  - folium
-  - gdal
   - geojson
   - geojsonio
   - geolinks
   - geopandas
-  - geos
   - gridgeo
-  - gsw
-  - ioos_tools
-  - iris>=1.12
+  - ioos-tools
   - jupyter
   - jupyter_contrib_nbextensions
-  - matplotlib
+  - jupyterthemes
+  - matplotlib=2
   - nb_conda_kernels
   - nbdime
   - nco
-  - netcdf4
-  - numpy
   - oceans
   - oct2py
-  - owslib
   - palettable
-  - pandas
   - phantomjs
   - pocean-core
-  - proj4
-  - psutil
-  - pygc
-  - pykdtree
   - pyoos
-  - pyproj
   - pyresample
   - pysgrid
   - pytest
   - pyugrid
-  - pyyaml
   - rasterio
-  - requests
-  - retrying
-  - rpy2
-  - rtree
-  - scikit-learn
-  - scipy
+  - rise
   - seaborn
-  - seawater
   - selenium
   - sensorml2iso
-  - shapely
   - siphon
   - spyder
-  - statsmodels
   - sympy
   - thredds_crawler
   - utide
   - windrose
   - xarray
   - xlrd
-  
+  - xmltodict
+  # R packages.
+  - rpy2
+  - r-base=3.5.1
+  - r-dt
+  - r-finch
+  - r-ggfortify
+  - r-ggplot2
+  - r-gsw
+  - r-httr
+  - r-irkernel
+  - r-lubridate
+  - r-mapdata
+  - r-ncdf4
+  - r-oce
+  - r-rcolorbrewer
+  - r-rerddap
+  - r-reshape2
+  - r-robis
+  - r-sp
+  - r-xtractomatic
+  - r-xts

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: IOOS
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.7
   - bagit
   - bokeh
   - cartopy
@@ -25,6 +25,7 @@ dependencies:
   - nb_conda_kernels
   - nbdime
   - nco
+  - oceans
   - oct2py
   - palettable
   - phantomjs
@@ -48,24 +49,3 @@ dependencies:
   - xarray
   - xlrd
   - xmltodict
-  # R packages.
-  - rpy2
-  - r-base=3.4.1
-  - r-dt
-  - r-finch
-  - r-ggfortify
-  - r-ggplot2
-  - r-gsw
-  - r-httr
-  - r-irkernel
-  - r-lubridate
-  - r-mapdata
-  - r-ncdf4
-  - r-oce
-  - r-rcolorbrewer
-  - r-rerddap
-  - r-reshape2
-  - r-robis
-  - r-sp
-  - r-xtractomatic
-  - r-xts

--- a/webpage/other_resources.md
+++ b/webpage/other_resources.md
@@ -59,7 +59,7 @@ export PATH=$HOME/miniconda3/bin:$PATH
 ## Create the IOOS Anaconda environment
 
 Download the [environment.yml](https://raw.githubusercontent.com/ioos/notebooks_demos/master/environment.yml),
-or the [environment-lite.yml](https://raw.githubusercontent.com/ioos/notebooks_demos/master/environment-lite.yml) for a smaller environment without the R packages,
+or the [environment-python_and_r.yml](https://raw.githubusercontent.com/ioos/notebooks_demos/master/environment-python_and_r.yml) for a bigger environment with the R packages,
 by right clicking with the mouse and choosing `save as...`,
 or, on `OS X` and `Linux`, use these commands to download:
 


### PR DESCRIPTION
This PR updates the IOOS env and change the default env to be Python only while keeping an extra env file for those who need R. The idea is to reduce incompatibilities due to the slow development in R packages and let Python users take advantage of the latest package version.

There are also some environment simplifications via the removal of packages that would be pulled b/c they are dependencies of other packages, and upgrades the env to Python 3.7.