### PR TITLE
Move to Python 3.9

### DIFF
--- a/.binder/environment-python_and_r.yml
+++ b/.binder/environment-python_and_r.yml
@@ -1,9 +1,8 @@
 name: IOOS
 channels:
   - conda-forge
-  - defaults
 dependencies:
-  - python=3.8
+  - python=3.9
   - bagit
   - bokeh
   - cartopy
@@ -25,6 +24,8 @@ dependencies:
   - hvplot
   - ioos-tools
   - ioos_qc
+  - ipyleaflet
+  - joblib
   - jupyter
   - matplotlib-base
   - nbdime

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,9 +1,8 @@
 name: IOOS
 channels:
   - conda-forge
-  - defaults
 dependencies:
-  - python=3.8
+  - python=3.9
   - bagit
   - bokeh
   - cartopy
@@ -26,6 +25,7 @@ dependencies:
   - ioos-tools
   - ioos_qc
   - ipyleaflet
+  - joblib
   - jupyter
   - matplotlib-base
   - nbdime


### PR DESCRIPTION
All the packages in the IOOS env are now available on Python 3.9.