### PR TITLE
Remove CI indicator from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # IOOS demonstrations and examples notebooks
 
-| Platform       | Status                                                                                                                                                                        |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Linux and OS X | [![Build Status](https://travis-ci.org/ioos/notebooks_demos.svg?branch=master)](https://travis-ci.org/ioos/notebooks_demos)                                                   |
-| Windows        | [![Build status](https://ci.appveyor.com/api/projects/status/0k2b8eurfg435xws/branch/master?svg=true)](https://ci.appveyor.com/project/ocefpaf/notebooks-demos/branch/master) |
-
-
 See the rendered version at https://ioos.github.io/notebooks_demos
 
 To suggest a notebook or ask questions please open an issue at: https://github.com/ioos/notebooks_demos/issues


### PR DESCRIPTION
We are no longer using Travis-CI or AppVeyor