### PR TITLE
Let's try to implement a binder image cache

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -11,4 +11,5 @@ RUN apt-get update && \
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 USER $NB_USER
 
+ADD CONDARC CONDARC
 COPY CONDARC /tmp/.condarc

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,16 +1,12 @@
-name: Build Notebook Container
-on: [pull_request]
+name: Binder
+on: [push]
+
 jobs:
-  build-image-without-pushing:
+  Create-MyBinderOrg-Cache:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout PR
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: test build
+    - name: cache binder build on mybinder.org
       uses: jupyterhub/repo2docker-action@master
       with:
-        NO_PUSH: 'true'
-        IMAGE_NAME: "ocefapf/repo2docker-test"
+        NO_PUSH: true
+        MYBINDERORG_TAG: ${{ github.event.ref }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,5 +1,9 @@
 name: Binder
-on: [push]
+
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   Create-MyBinderOrg-Cache:


### PR DESCRIPTION
This should not only help our binder instance to start up quickly but also make RStudio available.